### PR TITLE
Add suspend/resume on user presence and module hide/show

### DIFF
--- a/MMM-HomeAssistant-WebRTC.css
+++ b/MMM-HomeAssistant-WebRTC.css
@@ -1,3 +1,7 @@
+.MMM-HomeAssistant-WebRTC {
+  display: inline-block;
+}
+
 .region .haws-video {
   width: 100%;
   display: block;

--- a/MMM-HomeAssistant-WebRTC.js
+++ b/MMM-HomeAssistant-WebRTC.js
@@ -1,4 +1,4 @@
-Module.register("MMM-HomeAssistant-WebRTC", {
+Module.register('MMM-HomeAssistant-WebRTC', {
     video: null,
     pc: null,
     stream: null,
@@ -8,15 +8,15 @@ Module.register("MMM-HomeAssistant-WebRTC", {
     suspendedForUserPresence: false,
 
     defaults: {
-        host: "hassio.local",
-        port: "8123",
+        host: 'hassio.local',
+        port: '8123',
         https: false,
-        width: "50%",
-        token: "",
-        url: "",
+        width: '50%',
+        token: '',
+        url: '',
     },
 
-    start: function () {
+    start() {
         this._init();
     },
 
@@ -34,14 +34,14 @@ Module.register("MMM-HomeAssistant-WebRTC", {
         }
     },
 
-    getStyles: function () {
-        return [this.name + ".css"];
+    getStyles() {
+        return [this.name + '.css'];
     },
 
-    getDom: function () {
+    getDom() {
         if (this.stream) {
-            this.video = document.createElement("video");
-            this.video.classList.add("haws-video");
+            this.video = document.createElement('video');
+            this.video.classList.add('haws-video');
             this.video.autoplay = true;
             this.video.controls = false;
             this.video.volume = 1;
@@ -59,9 +59,9 @@ Module.register("MMM-HomeAssistant-WebRTC", {
             return this.video;
         }
 
-        const error = document.createElement("div");
-        error.classList.add("haws-error", "small");
-        error.innerHTML = "No data from Home Assistant";
+        const error = document.createElement('div');
+        error.classList.add('haws-error', 'small');
+        error.innerHTML = 'No data from Home Assistant';
         return error;
     },
 
@@ -82,11 +82,11 @@ Module.register("MMM-HomeAssistant-WebRTC", {
     },
 
     sendOffer(sdp) {
-        this.sendSocketNotification("OFFER", { config: this.config, sdp });
+        this.sendSocketNotification('OFFER', {config: this.config, sdp});
     },
 
-    socketNotificationReceived: function (notification, payload) {
-        if (notification === "ANSWER") {
+    socketNotificationReceived(notification, payload) {
+        if (notification === 'ANSWER') {
             this._start(payload.sdp);
             this.updateDom();
         }
@@ -107,12 +107,10 @@ Module.register("MMM-HomeAssistant-WebRTC", {
     async _init() {
         this.stream = new MediaStream();
         this.pc = new RTCPeerConnection({
-            iceServers: [
-                {
-                    urls: ["stun:stun.l.google.com:19302"],
-                },
-            ],
-            iceCandidatePoolSize: 20,
+            iceServers: [{
+                urls: ['stun:stun.l.google.com:19302']
+            }],
+            iceCandidatePoolSize: 20
         });
 
         this.pc.onicecandidate = (e) => {
@@ -123,46 +121,46 @@ Module.register("MMM-HomeAssistant-WebRTC", {
             if (e.candidate === null) {
                 this._connect();
             }
-        };
+        }
 
         this.pc.onconnectionstatechange = () => {
-            if (this.pc.connectionState === "failed") {
+            if (this.pc.connectionState === 'failed') {
                 this.pc.close();
                 this.video.srcObject = null;
                 this._init();
             }
-        };
+        }
 
         this.pc.ontrack = (event) => {
             this.stream.addTrack(event.track);
-        };
+        }
 
-        const pingChannel = this.pc.createDataChannel("ping");
+        const pingChannel = this.pc.createDataChannel('ping');
         let intervalId;
         pingChannel.onopen = () => {
             intervalId = setInterval(() => {
                 try {
-                    pingChannel.send("ping");
+                    pingChannel.send('ping');
                 } catch (e) {
                     console.warn(e);
                 }
             }, 1000);
-        };
+        }
         pingChannel.onclose = () => {
             clearInterval(intervalId);
-        };
+        }
 
-        this.pc.addTransceiver("video", { direction: "recvonly" });
+        this.pc.addTransceiver('video', {'direction': 'recvonly'});
 
         this._startConnectTimer();
-        const offer = await this.pc.createOffer({ offerToReceiveVideo: true });
+        const offer = await this.pc.createOffer({offerToReceiveVideo: true});
         return this.pc.setLocalDescription(offer);
     },
 
     _start(sdp) {
         try {
             const remoteDesc = new RTCSessionDescription({
-                type: "answer",
+                type: 'answer',
                 sdp,
             });
             this.pc.setRemoteDescription(remoteDesc);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,83 @@
 {
   "name": "mmm-homeassistant-webrtc",
   "version": "1.0.0",
-  "lockfileVersion": 1,
+  "lockfileVersion": 2,
   "requires": true,
+  "packages": {
+    "": {
+      "name": "mmm-homeassistant-webrtc",
+      "version": "1.0.0",
+      "license": "ISC",
+      "dependencies": {
+        "node-fetch": "^2.6.1"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "2.6.7",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o="
+    },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE="
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    }
+  },
   "dependencies": {
     "node-fetch": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
-      "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw=="
+      "version": "2.6.7",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+      "requires": {
+        "whatwg-url": "^5.0.0"
+      }
+    },
+    "tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o="
+    },
+    "webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE="
+    },
+    "whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
+      "requires": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
     }
   }
 }


### PR DESCRIPTION
First of all, THANK YOU for this module. It is exactly what I needed and is working well.

I borrowed some elements from my old module (MMM-RTSPStream) and wanted to share them back with you in case you wanted to include them in your code.

- Add suspend/resume functions to allow pausing the video stream on module show/hide (allows external control via MMM-Remote-Control API to quickly show a stream when needed, for example my front door when the doorbell is pressed).
- Add support for `USER_PRESENCE` notifications sent by various modules, again suspend/resume stream if no one is watching.
- Run `prettier` to format JS
- Update function statements to satisfy Linter
- Tweak CSS file to allow inheriting some positioning from MM2 "region" module containers (e.g. center the stream and only take up the middle column when `middle_center` is used. 